### PR TITLE
remove Compat from deps/build.jl

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,4 @@
 using BinDeps
-using Compat
 
 @BinDeps.setup
 


### PR DESCRIPTION
you aren't using it directly or listing it in your REQUIRE file,
and it's not guaranteed it'll always be present as a transitive dependency